### PR TITLE
Fix ANOVA code in Python notebook

### DIFF
--- a/Modelos_Lineales_Mixtos_en_Python.ipynb
+++ b/Modelos_Lineales_Mixtos_en_Python.ipynb
@@ -320,9 +320,10 @@
     "import statsmodels.stats.multicomp as multi\n",
     "\n",
     "# Ajuste ANOVA y comparaciones post hoc\n",
-    "anova_results = sm.stats.anova_lm(result_normal, typ=2)\n",
-    "print(anova_results)"
-   ]
+    "model_ols = smf.ols('score ~ program + school', data=data_normal).fit()\n",
+    "anova_results = sm.stats.anova_lm(model_ols, typ=2)\n",
+    "print(anova_results)\n"
+  ]
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary
- repair ANOVA example in the Python mixed models notebook

## Testing
- `pytest -q` *(fails: command not found)*